### PR TITLE
Automatically infer what symbols to export for wasm-bindgen

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -997,7 +997,7 @@ def phase_compile_inputs(options, state, newargs):
       # Default to assuming the inputs are object files and pass them to the linker
       pass
 
-  return [f.value for f in linker_args]
+  return linker_args
 
 
 def version_string():

--- a/tools/building.py
+++ b/tools/building.py
@@ -271,9 +271,6 @@ def get_wasm_bindgen_exported_symbols(input_files):
   symbols = []
   for line in result.stdout.splitlines():
     (path, symbol) = line.split()
-    # Skip system libraries which are not needed and causes bloat.
-    if path.find('bin/third_party/crosstool/rust/') != -1:
-      continue
     # Skip mangled (non-C) symbols
     if symbol.startswith('_Z') or symbol.startswith('_R'):
       continue


### PR DESCRIPTION
Export all C symbols, except perhaps those from system libraries